### PR TITLE
Configuring ImageContentSources should be optional. With this patch, …

### DIFF
--- a/roles/managed-clusters-role/templates/aws-install-config.yaml.j2
+++ b/roles/managed-clusters-role/templates/aws-install-config.yaml.j2
@@ -92,6 +92,7 @@ additionalTrustBundle:
 {% endfilter %}
 {% endif %}
 
+{% if repo is defined %}
 imageContentSources:
   - mirrors:
       - {{ repo }}/openshift/openshift-release-images
@@ -105,3 +106,4 @@ imageContentSources:
   - mirrors:
       - {{ repo }}/rhacm2
     source: registry.redhat.io/rhacm2
+{% endif %}


### PR DESCRIPTION
…only if "repo" is defined it'll be configured.